### PR TITLE
Fix bug with uninitialized data_found output

### DIFF
--- a/DataMod_F90/generate_EMI_ALMTtype_DataMod_F90.m
+++ b/DataMod_F90/generate_EMI_ALMTtype_DataMod_F90.m
@@ -49,7 +49,7 @@ fprintf(fid,'    character (len=24) , intent(out) :: dim3_beg_name\n');
 fprintf(fid,'    character (len=24) , intent(out) :: dim3_end_name\n');
 fprintf(fid,'    character (len=24) , intent(out) :: dim4_beg_name\n');
 fprintf(fid,'    character (len=24) , intent(out) :: dim4_end_name\n');
-fprintf(fid,'    logical            , intent(out) :: data_found\n');
+fprintf(fid,'    logical            , intent(inout) :: data_found\n');
 fprintf(fid, '\n');
 fprintf(fid, '    is_int_type    = .false.\n');
 fprintf(fid, '    is_real_type   = .false.\n');

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ contains
     character (len=24) , intent(out) :: dim3_end_name
     character (len=24) , intent(out) :: dim4_beg_name
     character (len=24) , intent(out) :: dim4_end_name
-    logical            , intent(out) :: data_found
+    logical            , intent(inout) :: data_found
 
     is_int_type    = .false.
     is_real_type   = .false.


### PR DESCRIPTION
Change `data_found` from intent(out) to intent(inout) in DataMod subroutines. This fixes a bug with the value of data_found not being preserved in EMI_DataMod (which only showed up when I started using a different compiler on a Docker setup for some reason). 

This should address https://github.com/E3SM-Project/E3SM/issues/5593